### PR TITLE
GC logging and JMX

### DIFF
--- a/files/jvm.options
+++ b/files/jvm.options
@@ -235,8 +235,12 @@
 -XX:+PrintPromotionFailure
 #-XX:PrintFLSStatistics=1
 #-Xloggc:/var/log/cassandra/gc.log
--XX:+UseGCLogFileRotation
--XX:NumberOfGCLogFiles=10
--XX:GCLogFileSize=10M
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=10
+#-XX:GCLogFileSize=10M
+
 -javaagent:/usr/local/share/jolokia-agent.jar=host=0.0.0.0
 -javaagent:/usr/local/share/prometheus-agent.jar=1234:/etc/cassandra/prometheus.yaml
+
+# Debug
+-XX:+PrintCommandLineFlags


### PR DESCRIPTION
- Although the JMX port was open it was redirecting to 127.0.0.1 despite the RMI address being set. 
- GC logging was complaining about the log dir not existing when GC to STDOUT wasn't set
- Added a ENV for verbose GC logging
- Split the Dockerfile into two RUN commands. This cuts build time down when not updating the OS from 26m to <1m. Downside is that it's another layer. Is there a better way to accomplish the same?